### PR TITLE
Allow shuffling of three-person mobs

### DIFF
--- a/public/actions.js
+++ b/public/actions.js
@@ -333,7 +333,7 @@ export const UpdateName = (state, name) => ({
 export const ShuffleMob = (state) => {
   const mob = [...state.mob];
   for (let index = mob.length - 1; index > 0; index -= 1) {
-    const otherIndex = Math.floor(Math.random() * index);
+    const otherIndex = Math.round(Math.random() * index);
     const old = mob[index];
     mob[index] = mob[otherIndex];
     mob[otherIndex] = old;


### PR DESCRIPTION
This is a small improvement for the `mobShuffle` action. 

The current `mobShuffle` rotates, but does not shuffle, mobs of three people (`mobShuffle` is a near-perfect Knuth shuffle but the final swapped index is always zero).

The reason is the `Math.floor`: meaning that the final `otherIndex` (when the `index` is `1`) will always be zero. So the final swap is always between the firsth and zeroth element; and in the case of three items it will put the mob in new positions (rotated) but back in order.

I think the array access via `index` is still safe as I don't think you can get out of bounds because:
 - the `for` loop is only entered if `index` is greater than `0`, so it's not entered for mobs of size `1` as `1 - 1 === 0`  (we similarly stay out of the loop for mobs of `0` length)
 - `index` is always less than or equal to the nth index (it's bound to `length - 1`) so the upper bound is safe
 - `index` lower bound is safe due to the mentioned `for` loop constraint

`otherIndex` is now in `[0..index]` (used to be `[0..index)`)

Since `index` is safe it follows that `otherIndex` should be safe :)
