### PR TITLE
Bug/141 long goal names overflow

### DIFF
--- a/public/components/goal.js
+++ b/public/components/goal.js
@@ -10,6 +10,7 @@ export const goal = (props) => h('div', {
     'justify-between': true,
     'mb-2': true,
     'w-full': true,
+    'break-words': true,
     'truncate': props.truncate,
   },
 }, [

--- a/public/components/goal.js
+++ b/public/components/goal.js
@@ -45,6 +45,7 @@ export const goal = (props) => h('div', {
   h('label', {
     for: `goal-${props.id}`,
     class: {
+      'pr-1': true,
       'text-4xl': true,
       'flex-grow': true,
       'leading-tight': true,


### PR DESCRIPTION
Fixes #141 

Long words in goal content no longer cause a text overflow issue

![image](https://user-images.githubusercontent.com/6907518/94967880-f0d17e00-04cd-11eb-8b44-1f4e7f9d47ca.png)
