### PR TITLE
Bug/148 xl-size styles

### DIFF
--- a/public/timer.js
+++ b/public/timer.js
@@ -76,6 +76,8 @@ app({
           flex: true,
           'items-start': true,
           'justify-center': true,
+          'bg-indigo-700': true,
+          'min-h-screen': true,
         },
       },
       [
@@ -90,7 +92,7 @@ app({
               'sm:w-8/12': true,
               'md:w-10/12': true,
               'lg:w-6/12': true,
-              'xl:w-4/12': true,
+              'xl:w-6/12': true,
               shadow: false,
               'sm:shadow-lg': true,
               'pt-2': false,


### PR DESCRIPTION
Fixes #148 

### Current XL Screen
<img width="900" alt="Screen Shot 2020-10-08 at 3 55 23 PM" src="https://user-images.githubusercontent.com/25010884/95508844-9e86d600-0981-11eb-9658-b1b3332f505d.png">

### Proposed XL Screen
<img width="1674" alt="Screen Shot 2020-10-08 at 4 18 28 PM" src="https://user-images.githubusercontent.com/25010884/95509046-edcd0680-0981-11eb-9af1-f9ad67d88315.png">
