### PR TITLE
Remove unnecessary class

### DIFF
--- a/public/timer.js
+++ b/public/timer.js
@@ -92,7 +92,6 @@ app({
               'sm:w-8/12': true,
               'md:w-10/12': true,
               'lg:w-6/12': true,
-              'xl:w-6/12': true,
               shadow: false,
               'sm:shadow-lg': true,
               'pt-2': false,


### PR DESCRIPTION
Small nitpick, if a responsive style is set to a value that is the same as it's larger companion then it is not needed since they cascade up.